### PR TITLE
docs: refresh README to current state (H549)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 type: software
 title: csl-ldev
 message: If you use this software, please cite it.
-license: GPL-3.0
+license: CC-BY-SA-4.0
 repository-code: https://github.com/sanskrit-lexicon/csl-ldev
 keywords:
   - sanskrit

--- a/README.md
+++ b/README.md
@@ -1,54 +1,115 @@
 # csl-ldev
 
-CDSL **data-store** repository in the Sanskrit Lexicon project.
-lnum wise entry for data in csl-devanagari for Devanagari correction submission.
+_Created: 15-05-2026 · Last updated: 11-07-2026_
 
-## Tech Stack
+Per-entry (`lnum`-wise) data store for the Cologne Digital Sanskrit Lexicon
+(CDSL). Every dictionary entry from [csl-devanagari](https://github.com/sanskrit-lexicon/csl-devanagari)
+is split out into its own small file so a single entry can be linked, viewed, and
+corrected directly — without having to open the multi-megabyte per-dictionary source
+files.
 
-- **Runtime**: —
-- **Build**: per-repo workflow
-- **Pipeline**: see [csl-observatory tooling runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md)
+## Why this repository exists
 
-## Issues Overview
+The per-dictionary Devanagari sources in [csl-devanagari](https://github.com/sanskrit-lexicon/csl-devanagari)
+are single text files, some larger than 50 MB — impractical for a reader who wants to
+propose a correction to one entry, and too large for many editors to open. To make
+per-entry correction submission feasible (including from StarDict applications — see
+[indic-dict/stardict-sanskrit#122](https://github.com/indic-dict/stardict-sanskrit/issues/122)),
+each entry is copied out into its own file keyed by its `L`-number (`lnum`). A reader who
+finds an error in one entry can then edit or open a pull request against just that file.
 
-Snapshot 2026-05-29: **8** open, **1** closed.
+## Data organization
 
-### By Milestone
+- Files are laid out as `v02/<dictcode>/<lnum>.txt`. For example,
+  [v02/snp/35.txt](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/v02/snp/35.txt)
+  is entry `L=35` of the `snp` dictionary.
+- Each file is the verbatim `<L>…<LEND>` section copied from the corresponding
+  csl-devanagari source (e.g.
+  [snp.txt](https://github.com/sanskrit-lexicon/csl-devanagari/blob/master/v02/snp/snp.txt)).
+  A typical entry:
 
-| Milestone | Open | Closed | Total |
-|---|---:|---:|---:|
-| API Stability | 0 | 0 | 0 |
-| User Experience | 1 | 0 | 1 |
-| Data Quality | 6 | 0 | 6 |
-| Developer Experience | 0 | 0 | 0 |
-| Community | 1 | 0 | 1 |
+  ```
+  <L>35<pc>532<k1>ओष्ठोपमफला<k2>ओष्ठोपमफला
+  {%oṣṭhopamaphalā%}¦
+  <div n="lb"/>= {%bimbī.%}
+  <LEND>
+  ```
 
-### By Type
+- Dictionary codes currently present under
+  [v02/](https://github.com/sanskrit-lexicon/csl-ldev/tree/main/v02): `acc` `ae` `ap90`
+  `armh` `ben` `bhs` `bop` `bor` `bur` `cae` `ccs` `gra` `gst` `ieg` `inm` `krm` `lan`
+  `mci` `md` `mw` `mw72` `mwe` `pe` `pgn` `pui` `pw` `pwg` `sch` `shs` `skd` `snp` `stc`
+  `vcp` `vei` `wil` `yat`.
 
-```mermaid
-pie title Open issues by type
-    "bug" : 6
-    "enhancement" : 1
-    "question" : 1
-```
+## Scripts
 
-### By Severity
+See [scripts/](https://github.com/sanskrit-lexicon/csl-ldev/tree/main/scripts):
 
-```mermaid
-pie title Open issues by severity
-    "minor" : 7
-    "trivial" : 1
-```
+- [txt_to_ldev.py](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/scripts/txt_to_ldev.py)
+  — generate the `lnum`-wise entries for one dictionary code from its csl-devanagari
+  source, e.g. `python3 txt_to_ldev.py mw` populates `v02/mw/`.
+- [redo_all.sh](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/scripts/redo_all.sh)
+  — regenerate every dictionary from the latest csl-devanagari data: `bash redo_all.sh`.
+- [ldev_to_csldevanagari.py](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/scripts/ldev_to_csldevanagari.py)
+  — carry a correction made here back into csl-devanagari, taking `dictId` and `lnum`,
+  e.g. `python3 ldev_to_csldevanagari.py skd 15140` integrates `v02/skd/15140.txt` into
+  csl-devanagari's `v02/skd/skd.txt`.
 
-## GitHub Issue Conventions
+After a change is transferred back into csl-devanagari, propagate it onward to csl-orig
+from `csl-devanagari/scripts/`: `python3 to_slp1.py <dictId>`, then copy
+`../slp1/<dict>.txt` to `../../csl-orig/v02/<dictId>/<dictId>.txt`.
 
-Follows the [Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md):
+## Operational warning — do not run `git status` here
 
-- **17 type labels** across 5 categories
-- **4 severity levels**: trivial, minor, major, critical
-- **5 milestones**: API Stability, User Experience, Data Quality, Developer Experience, Community
-- **Domain labels** scoped to data-store: `domain:schema`, `domain:migration`, `domain:integrity`, `domain:storage`
-- **Org Project**: [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9)
+This repository holds well over a million small files. Running `git status` (or a full
+`git fetch`/clone with a working-tree checkout) at the CLI will try to index every file
+and can hang or exhaust the machine. Stage changed files by path directly
+(`git add <path>`) rather than relying on `git status`, and prefer editing individual
+files through the GitHub web/API rather than checking out the whole tree.
+
+## Relationship to other repositories
+
+- **Upstream source:** [csl-devanagari](https://github.com/sanskrit-lexicon/csl-devanagari)
+  — the base from which every entry file here is derived.
+- **Correction destination:** corrections flow back through csl-devanagari to
+  [csl-orig](https://github.com/sanskrit-lexicon/csl-orig), the canonical Cologne source.
+
+## License
+
+Content is released under **CC-BY-SA-4.0** (see
+[LICENSE](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/LICENSE)), per the
+RH1 license policy approved 2026-06-17.
+
+## GitHub issue conventions
+
+This is a tooling/data repository in the `sanskrit-lexicon` org and follows the
+[Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md).
+Each issue carries exactly one type label, one severity, and one milestone (see
+[CLAUDE.md](https://github.com/sanskrit-lexicon/csl-ldev/blob/main/CLAUDE.md) for the
+label lists); data-specific issues additionally use `domain:` labels
+(`domain:schema`, `domain:migration`, `domain:integrity`, `domain:storage`). Tool work
+across the org is tracked in the
+[Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9) project.
+
+### Open-issue snapshot (11-07-2026)
+
+**7 open · 2 closed.** All open issues concern svara/accent rendering and are labelled
+`domain:integrity`:
+
+| Type | Count |
+|---|---:|
+| bug | 5 |
+| enhancement | 1 |
+| question | 1 |
+
+| Severity | Count |
+|---|---:|
+| minor | 6 |
+| trivial | 1 |
+
+See the live list at
+[github.com/sanskrit-lexicon/csl-ldev/issues](https://github.com/sanskrit-lexicon/csl-ldev/issues).
 
 ---
-*Generated by Cologne Tooling Runbook on 2026-05-29*
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Part of **H549** — org-wide README refresh (tooling/infra repos group). Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H549-Opus_Uprava_readme-refresh-tooling-repos_10.07.26.md

## What changed

- **`README.md` rewritten.** The prior `README.md` was an auto-generated Cologne-tooling-runbook stub carrying a stale issue snapshot (dated 2026-05-29: "8 open, 1 closed") and generic em-dash "Tech Stack" placeholders, while the real substance of the repo lived only in the lowercase `readme.md`. The new `README.md` describes what csl-ldev actually is: the per-entry (`lnum`-wise) data store derived from csl-devanagari that enables per-entry correction links (incl. StarDict), with data layout, the three scripts, the correction round-trip back to csl-devanagari→csl-orig, and the critical operational warning against running `git status` on a repo of 1M+ files.
- **Live issue snapshot** corrected to 11-07-2026 (**7 open, 2 closed** — all svara/accent `domain:integrity`; 5 bug / 1 enhancement / 1 question), verified via the issues API rather than trusting the old README.
- **`CITATION.cff` license fixed** GPL-3.0 → CC-BY-SA-4.0, to match the actual `LICENSE` file (CC-BY-SA-4.0, added under the RH1 policy approved 2026-06-17). This was a real source-of-truth discrepancy, fixed at source per the handoff.
- Org Markdown conventions applied: dated header (real creation date 15-05-2026 from git history), byline, no raw HTML, full blob/tree URLs.

## Notes
- No `readme-guard` workflow / MANUAL markers in this repo (only `dependabot-auto-merge.yml`), so nothing verbatim to preserve.
- The lowercase `readme.md` (original hand-written doc) is left in place; its content is now reflected and expanded in `README.md`.
- Committed via the GitHub API: a local working-tree checkout is infeasible here (1M+ files — the repo's own README warns against it, and `git fetch`/`git status` time out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)